### PR TITLE
K8S_redis starting point for K8S specific changes

### DIFF
--- a/base/cluster_apply.sh
+++ b/base/cluster_apply.sh
@@ -1,0 +1,15 @@
+kubectl apply \
+-f apolloserver-deployment.yaml \
+-f apolloserver-service.yaml \
+-f redis-master-deployment.yaml \
+-f redis-master-service.yaml \
+-f redis-replica-deployment.yaml \
+-f redis-replica-service.yaml \
+-f lb-deployment.yaml \
+-f lb-service.yaml \
+-f fix-redis-volume-ownership-deployment.yaml \
+-f fix-redis-volume-ownership-claim0-persistentvolumeclaim.yaml \
+-f fix-redis-volume-ownership-claim1-persistentvolumeclaim.yaml \
+-f lb-claim0-persistentvolumeclaim.yaml \
+-f redis-master-claim1-persistentvolumeclaim.yaml \
+-f redis-master-claim0-persistentvolumeclaim.yaml

--- a/base/cluster_delete.sh
+++ b/base/cluster_delete.sh
@@ -1,0 +1,15 @@
+kubectl delete \
+-f apolloserver-deployment.yaml \
+-f apolloserver-service.yaml \
+-f redis-master-deployment.yaml \
+-f redis-master-service.yaml \
+-f redis-replica-deployment.yaml \
+-f redis-replica-service.yaml \
+-f lb-deployment.yaml \
+-f lb-service.yaml \
+-f fix-redis-volume-ownership-deployment.yaml \
+-f fix-redis-volume-ownership-claim0-persistentvolumeclaim.yaml \
+-f fix-redis-volume-ownership-claim1-persistentvolumeclaim.yaml \
+-f lb-claim0-persistentvolumeclaim.yaml \
+-f redis-master-claim1-persistentvolumeclaim.yaml \
+-f redis-master-claim0-persistentvolumeclaim.yaml

--- a/base/fix-redis-volume-ownership-deployment.yaml
+++ b/base/fix-redis-volume-ownership-deployment.yaml
@@ -21,17 +21,49 @@ spec:
       labels:
         io.kompose.service: fix-redis-volume-ownership
     spec:
+      securityContext:
+        runAsUser: 0
       containers:
-      - args:
-        - chown
-        - -R
-        - 1001:1001
-        - /bitnami
-        image: bitnami/redis:latest
-        name: fix-redis-volume-ownership
-        resources: {}
+      - name: fix-redis-volume-ownership
+        image: "docker.io/bitnami/redis:latest"
+        imagePullPolicy: "Always"
+        env:
+        - name: REDIS_REPLICATION_MODE
+          value: master
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DISABLE_COMMANDS
+          value:
+        ports:
+        - name: redis
+          containerPort: 6379
+        livenessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command:
+            - redis-cli
+            - ping
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command:
+            - redis-cli
+            - ping
+        resources:
+          null
+
         volumeMounts:
-        - mountPath: /bitnami
+        - mountPath: /bitnami/redis/data
           name: fix-redis-volume-ownership-claim0
         - mountPath: /opt/bitnami/redis/conf/redis.conf
           name: fix-redis-volume-ownership-claim1

--- a/base/lb-claim0-persistentvolumeclaim.yaml
+++ b/base/lb-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: lb-claim0
+  name: lb-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/base/lb-deployment.yaml
+++ b/base/lb-deployment.yaml
@@ -6,11 +6,12 @@ metadata:
     kompose.version: 1.19.0 (f63a961c)
   creationTimestamp: null
   labels:
-    io.kompose.service: apolloserver
-  name: apolloserver
+    io.kompose.service: lb
+  name: lb
 spec:
   replicas: 1
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -18,13 +19,20 @@ spec:
         kompose.version: 1.19.0 (f63a961c)
       creationTimestamp: null
       labels:
-        io.kompose.service: apolloserver
+        io.kompose.service: lb
     spec:
       containers:
-      - image: radkin/apolloserver:latest
-        name: apolloserver
+      - image: dockercloud/haproxy
+        name: lb
         ports:
-        - containerPort: 9000
+        - containerPort: 80
         resources: {}
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: lb-claim0
       restartPolicy: Always
+      volumes:
+      - name: lb-claim0
+        persistentVolumeClaim:
+          claimName: lb-claim0
 status: {}

--- a/base/lb-service.yaml
+++ b/base/lb-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.19.0 (f63a961c)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: lb
+  name: lb
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    targetPort: 80
+  selector:
+    io.kompose.service: lb
+status:
+  loadBalancer: {}

--- a/base/redis-master-deployment.yaml
+++ b/base/redis-master-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         io.kompose.service: redis-master
     spec:
+      securityContext:
+        runAsUser: 0
       containers:
       - env:
         - name: ALLOW_EMPTY_PASSWORD
@@ -33,7 +35,7 @@ spec:
         - containerPort: 6379
         resources: {}
         volumeMounts:
-        - mountPath: /bitnami
+        - mountPath: /bitnami/redis/data
           name: redis-master-claim0
         - mountPath: /opt/bitnami/redis/conf/redis.conf
           name: redis-master-claim1

--- a/base/redis-replica-deployment.yaml
+++ b/base/redis-replica-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         io.kompose.service: redis-replica
     spec:
+      securityContext:
+        runAsUser: 0
       containers:
       - env:
         - name: ALLOW_EMPTY_PASSWORD

--- a/base/redis_cluster_apply.sh
+++ b/base/redis_cluster_apply.sh
@@ -1,0 +1,10 @@
+kubectl apply \
+-f redis-master-deployment.yaml \
+-f redis-master-service.yaml \
+-f redis-replica-deployment.yaml \
+-f redis-replica-service.yaml \
+-f fix-redis-volume-ownership-deployment.yaml \
+-f fix-redis-volume-ownership-claim0-persistentvolumeclaim.yaml \
+-f fix-redis-volume-ownership-claim1-persistentvolumeclaim.yaml \
+-f redis-master-claim1-persistentvolumeclaim.yaml \
+-f redis-master-claim0-persistentvolumeclaim.yaml

--- a/base/redis_cluster_delete.sh
+++ b/base/redis_cluster_delete.sh
@@ -1,0 +1,10 @@
+kubectl delete \
+-f redis-master-deployment.yaml \
+-f redis-master-service.yaml \
+-f redis-replica-deployment.yaml \
+-f redis-replica-service.yaml \
+-f fix-redis-volume-ownership-deployment.yaml \
+-f fix-redis-volume-ownership-claim0-persistentvolumeclaim.yaml \
+-f fix-redis-volume-ownership-claim1-persistentvolumeclaim.yaml \
+-f redis-master-claim1-persistentvolumeclaim.yaml \
+-f redis-master-claim0-persistentvolumeclaim.yaml

--- a/redis-master-statefulset.yaml
+++ b/redis-master-statefulset.yaml
@@ -1,0 +1,86 @@
+kind: StatefulSet
+metadata:
+  name: rune-redis-master
+  labels:
+    app: redis
+    chart: redis-3.2.0
+    release: "rune-redis"
+    heritage: "Tiller"
+spec:
+  selector:
+    matchLabels:
+      release: "rune-redis"
+      role: master
+      app: redis
+  serviceName: "redis-master"
+  template:
+    metadata:
+      labels:
+        release: "rune-redis"
+        role: master
+        app: redis
+      annotations:
+        sidecar.istio.io/inject: "false"
+
+    spec:
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+      containers:
+      - name: rune-redis
+        image: "docker.io/bitnami/redis:4.0.9"
+        imagePullPolicy: "Always"
+        env:
+        - name: REDIS_REPLICATION_MODE
+          value: master
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DISABLE_COMMANDS
+          value:
+        ports:
+        - name: redis
+          containerPort: 6379
+        livenessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command:
+            - redis-cli
+            - ping
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command:
+            - redis-cli
+            - ping
+        resources:
+          null
+
+        volumeMounts:
+        - name: redis-data
+          mountPath: /bitnami/redis/data
+          subPath:
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+        labels:
+          app: "redis"
+          chart: redis-3.2.0
+          component: "master"
+          release: "rune-redis"
+          heritage: "Tiller"
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"


### PR DESCRIPTION
kompose convert has everything as close as possible for K8S, but since
docker-compose is a subset of our K8S configs we need to further define
things like pod affinity, etc.